### PR TITLE
add PAT token and use PAT token to push on protected main branch

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -44,11 +44,15 @@ jobs:
           rm Package.swift.bak
 
       - name: Commit and push changes
+        env:
+          GHA_PAT: ${{ secrets.GHA_PAT }}
         run: |
           git config user.name "Smile Identity"
           git config user.email "mobile@smileidentity.com"
           git add Package.swift
           git commit -m "Update Package.swift for version $VERSION"
+          # we use a PAT (personal access token) with repo permissions in order to be able to push to the protected main branch.
+          git remote set-url origin https://x-access-token:${GHA_PAT}@github.com/${{ github.repository }}.git
           git push origin main
 
       - name: Create Git Tag
@@ -86,11 +90,15 @@ jobs:
           rm ${{ env.FRAMEWORK_NAME }}.podspec.bak
 
       - name: Commit and push changes
+        env:
+          GHA_PAT: ${{ secrets.GHA_PAT }}
         run: |
           git config user.name "Smile Identity"
           git config user.email "mobile@smileidentity.com"
           git add ${{ env.FRAMEWORK_NAME }}.podspec
           git commit -m "Update podspec for version $VERSION"
+          # we use a PAT (personal access token) with repo permissions in order to be able to push to the protected main branch.
+          git remote set-url origin https://x-access-token:${GHA_PAT}@github.com/${{ github.repository }}.git
           git push origin main
 
       - name: Publish to CocoaPods


### PR DESCRIPTION
## Summary

https://github.com/smileidentity/smile-id-security/actions/runs/13591257951/job/37997711454 fails because it tries to push on the protected main branch. A workaround is to use a PAT token with repo access. This PR adds this.

## Known Issues
-

## Test Instructions
We need to merge this PR and then we can test the change by triggering a gh workflow with manual dispatch on the main branch.

## Screenshot
-
