### PR TITLE
fix sed commands

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -103,8 +103,8 @@ jobs:
 
       - name: Update podspec
         run: |
-          sed -i.bak -E "s/s.version\s*=\s*'.*'/s.version = '$VERSION'/" ${{ env.FRAMEWORK_NAME }}.podspec
-          sed -i.bak -E "s#s.source\s*=\s*\{.*\}#s.source = { :http => 'https://github.com/smileidentity/smile-id-security/raw/refs/heads/main/Releases/$VERSION/${{ env.FRAMEWORK_NAME }}.xcframework.zip'}#" ${{ env.FRAMEWORK_NAME }}.podspec
+          sed -i.bak "s/\(s\.version[[:space:]]*=[[:space:]]*\)'[0-9]*\.[0-9]*\.[0-9]*'/"'\1'\'"${VERSION}"\'"/" ${{ env.FRAMEWORK_NAME }}.podspec
+          sed -i.bak "s|https://github.com/smileidentity/smile-id-security/raw/refs/heads/main/Releases/.*\.zip|https://github.com/smileidentity/smile-id-security/raw/refs/heads/main/Releases/$VERSION/${{ env.FRAMEWORK_NAME }}.xcframework.zip|" ${{ env.FRAMEWORK_NAME }}.podspec
           rm ${{ env.FRAMEWORK_NAME }}.podspec.bak
 
       - name: Authenticate with Smiles Github Action Bot


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

This PR fixes the sed commands on the update of the cocoapods podspec, which didn't work due to bash interpreting single quotes as literal string.

## Known Issues
-

## Test Instructions
Testing needs to be done on the main branch.

## Screenshot

If applicable (e.g. UI changes), add screenshots to help explain your work.
