### PR TITLE
pulls the latest changes before we run the cocoapods ops

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -137,6 +137,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Pull latest changes
+        run: |
+          git checkout main
+          git pull origin main --rebase
+
       - name: Publish to CocoaPods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Story: https://app.shortcut.com/smileid/story/xxx

## Summary

Forgot to pull the latest changes, as such the PR was merged and we were still running the cocoapods release on the old version.

## Known Issues
-

## Test Instructions
-

## Screenshot
-
